### PR TITLE
fix: forward chunk to scanner after maxTotalSize error to close dangling readable

### DIFF
--- a/src/internal/multipart.ts
+++ b/src/internal/multipart.ts
@@ -213,7 +213,7 @@ export function make({
   return {
     write(chunk: Uint8Array) {
       if ((state.totalSize += chunk.length) > maxTotalSize) {
-        return onError(errMaxTotalSize)
+        onError(errMaxTotalSize)
       }
       return split.write(chunk)
     },


### PR DESCRIPTION
## Problem

When `maxTotalSize` is exceeded mid-file, `write()` returned early before calling `split.write(chunk)`. The boundary scanner never saw the chunk, so `onChunk(null)` was never called for the active file part — leaving its readable stream open indefinitely.

Callers that consume the file part's readable (e.g. `@effect/platform-bun`'s `toPersisted`) wait forever for the stream to close → hang. See effect-ts/effect#6284 for the downstream report.

## Root cause

```ts
write(chunk: Uint8Array) {
  if ((state.totalSize += chunk.length) > maxTotalSize) {
    return onError(errMaxTotalSize)  // ← early return; split.write never runs
  }
  return split.write(chunk)
}
```

Note that `maxPartSize` already handles this correctly — it calls `onError` but does **not** return early, so the chunk still reaches the scanner.

## Fix

Remove the early return to match the `maxPartSize` pattern:

```ts
write(chunk: Uint8Array) {
  if ((state.totalSize += chunk.length) > maxTotalSize) {
    onError(errMaxTotalSize)
  }
  return split.write(chunk)
}
```

The scanner sees the excess chunk, finds the part boundary, and calls `onChunk(null)` — closing the readable cleanly.

Fixes #38