### PR TITLE
accept characters above U+00FF in content-disposition parameter values

### DIFF
--- a/.changeset/unicode-filename-params.md
+++ b/.changeset/unicode-filename-params.md
@@ -2,4 +2,4 @@
 "multipasta": patch
 ---
 
-accept characters above U+00FF in content-disposition parameter values, so browser-serialized UTF-8 filenames (emoji, CJK, U+202F in macOS screenshot names) parse as file parts instead of degrading to nameless fields
+accept characters above U+00FF in content-disposition parameter values

--- a/.changeset/unicode-filename-params.md
+++ b/.changeset/unicode-filename-params.md
@@ -1,0 +1,5 @@
+---
+"multipasta": patch
+---
+
+accept characters above U+00FF in content-disposition parameter values, so browser-serialized UTF-8 filenames (emoji, CJK, U+202F in macOS screenshot names) parse as file parts instead of degrading to nameless fields

--- a/src/internal/contentType.ts
+++ b/src/internal/contentType.ts
@@ -14,17 +14,26 @@
  * qdtext        = HTAB / SP / %x21 / %x23-5B / %x5D-7E / obs-text
  * obs-text      = %x80-FF
  * quoted-pair   = "\" ( HTAB / SP / VCHAR / obs-text )
+ *
+ * obs-text is byte-oriented (%x80-FF), but this parser receives header
+ * values already UTF-8 decoded (internal/headers.ts), so characters above
+ * U+00FF arrive as single code points. Browsers serialize multipart
+ * name/filename parameters as raw UTF-8 per the WHATWG HTML spec, so the
+ * quoted-string ranges extend to U+10FFFF; the structural quote and
+ * backslash exclusions are unchanged.
  */
 const paramRE =
-  /; *([!#$%&'*+.^\w`|~-]+)=("(?:[\v\u0020\u0021\u0023-\u005b\u005d-\u007e\u0080-\u00ff]|\\[\v\u0020-\u00ff])*"|[!#$%&'*+.^\w`|~-]+) */gu
+  /; *([!#$%&'*+.^\w`|~-]+)=("(?:[\v\u0020\u0021\u0023-\u005b\u005d-\u007e\u0080-\u{10ffff}]|\\[\v\u0020-\u{10ffff}])*"|[!#$%&'*+.^\w`|~-]+) */gu
 
 /**
  * RegExp to match quoted-pair in RFC 7230 sec 3.2.6
  *
  * quoted-pair = "\" ( HTAB / SP / VCHAR / obs-text )
  * obs-text    = %x80-FF
+ *
+ * Extended past obs-text for the same reason as paramRE above.
  */
-const quotedPairRE = /\\([\v\u0020-\u00ff])/gu
+const quotedPairRE = /\\([\v\u0020-\u{10ffff}])/gu
 
 /**
  * RegExp to match type in RFC 7231 sec 3.1.1.1

--- a/test/multipart.test.ts
+++ b/test/multipart.test.ts
@@ -580,6 +580,46 @@ const cases: ReadonlyArray<MultipartCase> = [
     ],
     name: "multiple empty parts should get ignored",
   },
+  {
+    source: [
+      [
+        "------WebKitFormBoundaryUnicodeName",
+        'Content-Disposition: form-data; name="purpose"',
+        "",
+        "attachment",
+        "------WebKitFormBoundaryUnicodeName",
+        'Content-Disposition: form-data; name="screenshot"; filename="Screenshot 2026-07-02 at 11.06.31 PM.png"',
+        "Content-Type: image/png",
+        "",
+        "AAAA",
+        "------WebKitFormBoundaryUnicodeName",
+        'Content-Disposition: form-data; name="emoji"; filename="emoji \u{1f600}.png"',
+        "Content-Type: image/png",
+        "",
+        "BBBB",
+        "------WebKitFormBoundaryUnicodeName",
+        'Content-Disposition: form-data; name="cjk"; filename="漢字.png"',
+        "Content-Type: image/png",
+        "",
+        "CCCC",
+        "------WebKitFormBoundaryUnicodeName--",
+      ].join("\r\n"),
+    ],
+    boundary: "----WebKitFormBoundaryUnicodeName",
+    expected: [
+      ["field", "purpose", "attachment", "text/plain"],
+      [
+        "file",
+        "screenshot",
+        4,
+        "Screenshot 2026-07-02 at 11.06.31 PM.png",
+        "image/png",
+      ],
+      ["file", "emoji", 4, "emoji \u{1f600}.png", "image/png"],
+      ["file", "cjk", 4, "漢字.png", "image/png"],
+    ],
+    name: "filenames beyond Latin-1 stay file parts",
+  },
 ]
 
 describe("multipart", () => {


### PR DESCRIPTION
## Symptom

A browser-shaped `multipart/form-data` body whose `filename` (or `name`) contains any character above U+00FF — emoji, CJK, or the U+202F narrow no-break space macOS puts in screenshot names (`Screenshot 2026-07-02 at 11.06.31 PM.png`) — loses its `Content-Disposition` parameters entirely: `onFile` never fires and the part surfaces as a nameless field. Minimal repro against the parser:

```ts
import * as Multipasta from "multipasta"

const form = new FormData()
form.append("purpose", "attachment")
form.append("file", new File([new Uint8Array(4)], "emoji 😀.png", { type: "image/png" }))
const request = new Request("http://localhost/", { method: "POST", body: form })
const body = new Uint8Array(await request.arrayBuffer())

const parser = Multipasta.make({
  headers: { "content-type": request.headers.get("content-type")! },
  onField: (info) => console.log("field", info.name),
  onFile: (info) => (console.log("file", info.filename), () => {}),
  onError: (e) => console.log("error", e),
  onDone: () => {},
})
parser.write(body)
parser.end()
// field purpose
// field        <- the file part, with no name and no filename
```

## Root cause

Part header values reach the content-type parser already UTF-8 decoded (`internal/headers.ts` uses `new TextDecoder()`), but `paramRE` in `internal/contentType.ts` applies RFC 7230's quoted-string grammar, whose `obs-text = %x80-FF` is byte-oriented. After UTF-8 decoding, a multi-byte character is a single code point above U+00FF, so the regex stops matching, `parse` bails to the parameterless default, and the part loses `name`/`filename`.

The input is legitimate: the WHATWG HTML multipart serialization sends `name`/`filename` as raw UTF-8 bytes (escaping only CR, LF, and `"`), and that is what Chrome/Firefox/Safari, undici, and Bun all emit.

## Fix

Widen the quoted-string content and quoted-pair ranges from `ÿ` to `\u{10ffff}` in `paramRE`, and the same in `quotedPairRE` so an escaped character above U+00FF also unescapes consistently. The token grammar and the structural `"` / `\` exclusions are untouched, so behavior for ASCII and Latin-1 inputs is byte-for-byte identical.

## Test

One new table case in `test/multipart.test.ts` driving the U+202F screenshot name, an emoji filename, and a CJK filename through all four suites. It fails on the core `multipart` suite before the fix (`× multipart > filenames beyond Latin-1 stay file parts`) and the full suite passes after (102/102, `tsc -b` clean).

Context: we hit this in production behind `@effect/platform`'s multipart handling (macOS screenshot uploads) and currently carry this change as a package patch; upstreaming so the patch can be deleted.
